### PR TITLE
Fix wasm build script and use https for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,11 @@
 	path = deps/emsdk
 	url = https://github.com/emscripten-core/emsdk.git
 [submodule "deps/wa-sqlite"]
-	path = deps/wa-sqlite
-	url = git@github.com:vlcn-io/wa-sqlite.git
+        path = deps/wa-sqlite
+        url = https://github.com/vlcn-io/wa-sqlite.git
 [submodule "deps/cr-sqlite"]
-	path = deps/cr-sqlite
-	url = git@github.com:vlcn-io/cr-sqlite.git
+        path = deps/cr-sqlite
+        url = https://github.com/vlcn-io/cr-sqlite.git
+[submodule "deps/cr-sqlite/core/rs/sqlite-rs-embedded"]
+        path = deps/cr-sqlite/core/rs/sqlite-rs-embedded
+        url = https://github.com/vlcn-io/sqlite-rs-embedded.git

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ native-ext = ./node_modules/@vlcn.io/crsqlite/dist/crsqlite.dylib
 all: $(git-deps) $(wasm-file) $(tsbuildinfo) $(native-ext)
 
 $(git-deps):
-	git submodule update --init --recursive
+	git submodule sync --recursive
+	git submodule update --init
+	git -C deps/cr-sqlite submodule sync --recursive || true
+	git -C deps/cr-sqlite config submodule.core/rs/sqlite-rs-embedded.url https://github.com/vlcn-io/sqlite-rs-embedded.git || true
+	git -C deps/cr-sqlite submodule update --init --recursive || true
 
 $(node-deps): $(git-deps)
 	bun install

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -8,6 +8,10 @@ cd deps/emsdk
 ./emsdk activate 3.1.45
 source ./emsdk_env.sh
 cd ../wa-sqlite
-make
+# Ensure the generated sqlite3-extra.c file is present before building
+# the final distribution artifacts. The wa-sqlite build does not create
+# this file automatically when invoking the default target, which causes
+# "No rule to make target 'tmp/obj/dist/sqlite3-extra.o'" failures.
+make crsqlite-extra dist
 cp dist/crsqlite.wasm ../../packages/crsqlite-wasm/dist/crsqlite.wasm
 cp dist/crsqlite.mjs ../../packages/crsqlite-wasm/src/crsqlite.mjs


### PR DESCRIPTION
## Summary
- use https for git submodules
- generate sqlite3-extra.c before building wasm output
- sync nested submodule URLs so builds work without ssh access

## Testing
- `make` *(fails: curl: (56) CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68984a6517ec832f9a331c7cb12b936c